### PR TITLE
Fix unnamed vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This project follows semantic versioning.
 
 ### Unreleased
+- [fixed] Bug when repeating a type in an unnamed variant.
 
 ### 0.1.0 (2023-02-13)
 - [added] Initial `subenum` macro creation.

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -1,0 +1,18 @@
+use subenum::subenum;
+
+#[subenum]
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Foo {
+    #[subenum(Bar)]
+    A(String, String, String, i32, i32, i32, u32, i32),
+    #[subenum(Bar)]
+    B {
+        x: i32,
+        y: i32,
+        z: String,
+        w: String,
+    },
+}
+
+#[test]
+fn test() {}


### PR DESCRIPTION
We can't use the type name for unnamed fields, as the types can be repeated.