### PR TITLE
Disambiguate Error type in TryFrom

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -180,7 +180,7 @@ impl Enum {
             impl #parent_impl core::convert::TryFrom<#parent_ident #parent_ty> for #child_ident #child_ty #parent_where {
                 type Error = #error;
 
-                fn try_from(parent: #parent_ident #parent_ty) -> Result<Self, Self::Error> {
+                fn try_from(parent: #parent_ident #parent_ty) -> Result<Self, <Self as core::convert::TryFrom<#parent_ident #parent_ty>>::Error> {
                     match parent {
                         #(#try_from_parent_arms),*,
                         _ => Err(#error)

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -72,3 +72,18 @@ enum Whew<'a: 'b, 'b, 'c, T, U> {
     #[subenum(Phew)]
     B(&'b [&'c [U; 7]]),
 }
+
+#[subenum(SubEnumWithErrorVariant)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum EnumWithErrorVariant {
+    #[subenum(SubEnumWithErrorVariant)]
+    Error,
+}
+
+#[test]
+fn test_enum_with_error_variant() {
+    let a = EnumWithErrorVariant::Error;
+    let b = SubEnumWithErrorVariant::try_from(a).unwrap();
+
+    assert_eq!(a, b);
+}


### PR DESCRIPTION
When trying to use `subenum` on an enum containing a variant named `Error`,
I got a compiler error, helpfully pointing me to this issue: https://github.com/rust-lang/rust/issues/57644

This is due to the `TryFrom` implementation generated by subenum, where it is now ambiguous whether
`Self::Error` refers to the associated type `TryFrom::Error` or to the enum variant `Error`.

This PR fixes this by disambiguating in the return type of `try_from`.   
