### PR TITLE
Fix nightly build / simplify no_std

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -1,6 +1,6 @@
+use alloc::{format, vec::Vec};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use std::{format, vec::Vec};
 use syn::{punctuated::Punctuated, DeriveInput, Generics, Ident, Token, TypeParamBound, Variant};
 
 use crate::{

--- a/src/enum.rs
+++ b/src/enum.rs
@@ -1,6 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
-use std::vec::Vec;
-
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 use proc_macro2::TokenStream;
 use syn::{punctuated::Punctuated, Generics, Ident, Token, TypeParamBound, Variant};
 

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -1,6 +1,4 @@
-use std::borrow::ToOwned;
-use std::boxed::Box;
-use std::vec::Vec;
+use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
 use syn::{Ident, Lifetime, Type, TypeParamBound};
 
 use crate::{iter::BoxedIter, param::Param};

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,4 +1,4 @@
-use std::boxed::Box;
+use alloc::boxed::Box;
 
 pub trait BoxedIter {
     type Item;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,7 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(feature = "std")]
-extern crate std;
-
-#[cfg(not(feature = "std"))]
-extern crate alloc as std;
+extern crate alloc;
 
 mod build;
 mod derive;
@@ -14,9 +10,7 @@ mod extractor;
 mod iter;
 mod param;
 
-use std::collections::BTreeMap;
-#[cfg(not(feature = "std"))]
-use std::{borrow::ToOwned, string::ToString, vec::Vec};
+use alloc::{borrow::ToOwned, collections::BTreeMap, string::ToString, vec::Vec};
 
 use derive::Derive;
 use heck::ToSnakeCase;
@@ -170,12 +164,7 @@ pub fn subenum(args: TokenStream, tokens: TokenStream) -> TokenStream {
                     };
 
                     // We want all attributes except the "subenum" one.
-                    var.attrs = var
-                        .attrs
-                        .iter()
-                        .cloned()
-                        .filter(|attr| attribute != attr)
-                        .collect();
+                    var.attrs.retain(|attr| attribute != attr);
 
                     let e = enums
                         .get_mut(ident)

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,6 +1,4 @@
-use std::collections::BTreeMap;
-use std::vec::Vec;
-
+use alloc::{collections::BTreeMap, vec::Vec};
 use syn::{GenericParam, Generics, Ident, Lifetime, TypeParamBound, WherePredicate};
 
 use crate::extractor::Extractor;


### PR DESCRIPTION
We were using `alloc` as `std` when the `std` feature was not present. However, there is a new nightly warning about redundant imports that this was raising, as `use std::vec::Vec`, for example, is not needed when using `std`.

Instead, we just use `alloc` always.