### PR TITLE
feat: Add parent-specific attribute support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This project follows semantic versioning.
 
 ### Unreleased
+- [added] Support for parent-specific proc-macros.
 
 ### 1.1.3 (2025-10-01)
 - [changed] Bumped dependency versions

--- a/README.md
+++ b/README.md
@@ -136,14 +136,14 @@ fn main() {
 
 ## Parent-specific proc-macros
 
-You can also specify attributes to be added to the parent enums only (i.e., the enum being `subenum`ed) via its same identifier (or the `Self` identifier), which can be used for things like documentation:
+You can also specify attributes to be added to the parent enums only (i.e., the enum being `subenum`ed) via its same identifier, which can be used for things like documentation:
 
 ```rust
 use subenum::subenum;
 
 /// Generic value type
 #[subenum(
-    Self(doc = "Numeric type\n"), // equals to `Num(doc = "Numeric type\n")`
+    Num(doc = "Numeric type\n"), // This will be added to Num itself, but not to Float or Int.
     Float(doc = "Floating point type\n"),
     Int(doc = "Integer type\n")
 )]
@@ -151,7 +151,7 @@ use subenum::subenum;
 pub enum Num {
     /// 64-bit floating point type (Generic)
     #[subenum(
-        Self(doc = "64-bit floating point type (Num)\n"),
+        Num(doc = "64-bit floating point type (Num)\n"),
         Float(doc = "64-bit floating point type (Float)\n")
     )]
     F64(f64),
@@ -172,7 +172,7 @@ pub enum Num {
 
     /// 32-bit integer type (Generic)
     #[subenum(
-        Self(doc = "32-bit integer type (Num)\n"),
+        Num(doc = "32-bit integer type (Num)\n"),
         Int(doc = "32-bit integer type (Int)\n")
     )]
     I32(i32),

--- a/README.md
+++ b/README.md
@@ -134,6 +134,51 @@ fn main() {
 }
 ```
 
+## Parent-specific proc-macros
+
+You can also specify attributes to be added to the parent enums only (i.e., the enum being `subenum`ed) via its same identifier (or the `Self` identifier), which can be used for things like documentation:
+
+```rust
+use subenum::subenum;
+
+/// Generic value type
+#[subenum(
+    Self(doc = "Numeric type\n"), // equals to `Num(doc = "Numeric type\n")`
+    Float(doc = "Floating point type\n"),
+    Int(doc = "Integer type\n")
+)]
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Num {
+    /// 64-bit floating point type (Generic)
+    #[subenum(
+        Self(doc = "64-bit floating point type (Num)\n"),
+        Float(doc = "64-bit floating point type (Float)\n")
+    )]
+    F64(f64),
+
+    /// 32-bit floating point type (Generic)
+    #[subenum(
+        Num(doc = "32-bit floating point type (Num)\n"),
+        Float(doc = "32-bit floating point type (Float)\n")
+    )]
+    F32(f32),
+
+    /// 64-bit integer type (Generic)
+    #[subenum(
+        Num(doc = "64-bit integer type (Num)\n"),
+        Int(doc = "64-bit integer type (Int)\n")
+    )]
+    I64(i64),
+
+    /// 32-bit integer type (Generic)
+    #[subenum(
+        Self(doc = "32-bit integer type (Num)\n"),
+        Int(doc = "32-bit integer type (Int)\n")
+    )]
+    I32(i32),
+}
+```
+
 
 # Limitations
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -97,7 +97,7 @@ impl Enum {
     }
 
     pub fn build(&self, parent: &mut DeriveInput, child_attrs: &[Attribute]) -> TokenStream2 {
-        if self.ident == "Self" || self.ident == parent.ident {
+        if self.ident == parent.ident {
             parent.attrs.extend(self.attributes.clone());
             return Default::default();
         }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,7 +1,9 @@
 use alloc::{format, vec::Vec};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use syn::{punctuated::Punctuated, DeriveInput, Generics, Ident, Token, TypeParamBound, Variant};
+use syn::{
+    punctuated::Punctuated, Attribute, DeriveInput, Generics, Ident, Token, TypeParamBound, Variant,
+};
 
 use crate::{
     derive::{partial_eq::partial_eq_arm, Derive},
@@ -94,9 +96,13 @@ impl Enum {
         }
     }
 
-    pub fn build(&self, parent: &DeriveInput) -> TokenStream2 {
+    pub fn build(&self, parent: &mut DeriveInput, child_attrs: &[Attribute]) -> TokenStream2 {
+        if self.ident == "Self" || self.ident == parent.ident {
+            parent.attrs.extend(self.attributes.clone());
+            return Default::default();
+        }
+
         let attributes = self.attributes.clone();
-        let child_attrs = parent.attrs.clone();
         let variants = self
             .variants
             .iter()
@@ -147,7 +153,7 @@ impl Enum {
         );
 
         quote!(
-            #(#[ #attributes ])*
+            #(#attributes)*
             #(#child_attrs)*
             #vis enum #child_ident #child_generics {
                 #(#variants),*

--- a/src/enum.rs
+++ b/src/enum.rs
@@ -2,22 +2,21 @@ use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec::Vec,
 };
-use proc_macro2::TokenStream;
-use syn::{punctuated::Punctuated, Generics, Ident, Token, TypeParamBound, Variant};
+use syn::{punctuated::Punctuated, Attribute, Generics, Ident, Token, TypeParamBound, Variant};
 
 use crate::{extractor::Extractor, iter::BoxedIter, param::Param, Derive};
 
 pub struct Enum {
     pub ident: Ident,
     pub variants: Punctuated<Variant, Token![,]>,
-    pub variants_attributes: Vec<Vec<TokenStream>>,
-    pub attributes: Vec<TokenStream>,
+    pub variants_attributes: Vec<Vec<Attribute>>,
+    pub attributes: Vec<Attribute>,
     pub derives: Vec<Derive>,
     pub generics: Generics,
 }
 
 impl Enum {
-    pub fn new(ident: Ident, attributes: Vec<TokenStream>, derives: Vec<Derive>) -> Self {
+    pub fn new(ident: Ident, attributes: Vec<Attribute>, derives: Vec<Derive>) -> Self {
         Enum {
             ident,
             variants: Punctuated::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use proc_macro2::Ident;
 use quote::quote;
 use r#enum::Enum;
 use syn::punctuated::Punctuated;
-use syn::{parse_macro_input, DeriveInput, Field, Meta, MetaList, MetaNameValue, Token, Type};
+use syn::{parse_macro_input, DeriveInput, Field, Meta, Token, Type};
 
 const SUBENUM: &str = "subenum";
 const ERR: &str =
@@ -68,13 +68,7 @@ fn build_enum_map(
                 ml.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
                     .expect(ERR)
                     .into_iter()
-                    .map(|meta| match meta {
-                        Meta::Path(path) => quote! { #path },
-                        Meta::List(MetaList { path, tokens, .. }) => quote! { #path(#tokens) },
-                        Meta::NameValue(MetaNameValue { path, value, .. }) => {
-                            quote! { #path = #value }
-                        }
-                    })
+                    .map(|meta| syn::parse_quote!(#[#meta]))
                     .collect(),
             ),
 
@@ -94,7 +88,7 @@ pub fn subenum(args: TokenStream, tokens: TokenStream) -> TokenStream {
     let args = parse_macro_input!(args with Punctuated::<Meta, syn::Token![,]>::parse_terminated);
     let mut input = parse_macro_input!(tokens as DeriveInput);
     let data = match input.data {
-        syn::Data::Enum(ref data) => data,
+        syn::Data::Enum(ref mut data) => data,
         _ => panic!("subenum may only be used on enums."),
     };
 
@@ -118,7 +112,8 @@ pub fn subenum(args: TokenStream, tokens: TokenStream) -> TokenStream {
     }
     let mut enums = build_enum_map(args, &derives);
 
-    for variant in &data.variants {
+    let mut self_variant_attrs = alloc::vec![Vec::new(); data.variants.len()];
+    for (variant, self_attrs) in data.variants.iter().zip(&mut self_variant_attrs) {
         for attribute in &variant.attrs {
             // Check for "subenum", iterate through the idents.
             if attribute.path().is_ident(SUBENUM) {
@@ -135,15 +130,7 @@ pub fn subenum(args: TokenStream, tokens: TokenStream) -> TokenStream {
                             ml.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
                                 .expect(ERR)
                                 .into_iter()
-                                .map(|meta| match meta {
-                                    Meta::Path(path) => quote! { #[ #path ] },
-                                    Meta::List(MetaList { path, tokens, .. }) => {
-                                        quote! { #[ #path(#tokens) ] }
-                                    }
-                                    Meta::NameValue(MetaNameValue { path, value, .. }) => {
-                                        quote! { #[ #path = #value ] }
-                                    }
-                                })
+                                .map(|meta| syn::parse_quote!(#[#meta]))
                                 .collect(),
                         ),
                         _ => unimplemented!("e"),
@@ -151,6 +138,11 @@ pub fn subenum(args: TokenStream, tokens: TokenStream) -> TokenStream {
 
                     // We want all attributes except the "subenum" one.
                     var.attrs.retain(|attr| attribute != attr);
+
+                    if ident == "Self" || ident == input.ident {
+                        self_attrs.extend(attrs);
+                        continue;
+                    }
 
                     let e = enums
                         .get_mut(&ident)
@@ -161,12 +153,19 @@ pub fn subenum(args: TokenStream, tokens: TokenStream) -> TokenStream {
             }
         }
     }
+    for (variants, self_attrs) in data.variants.iter_mut().zip(self_variant_attrs) {
+        variants.attrs.extend(self_attrs);
+    }
 
     for e in enums.values_mut() {
         e.compute_generics(&input.generics);
     }
 
-    let enums: Vec<_> = enums.into_values().map(|e| e.build(&input)).collect();
+    let attrs = input.attrs.clone();
+    let enums: Vec<_> = enums
+        .into_values()
+        .map(|e| e.build(&mut input, &attrs))
+        .collect();
 
     sanitize_input(&mut input);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ pub fn subenum(args: TokenStream, tokens: TokenStream) -> TokenStream {
                     // We want all attributes except the "subenum" one.
                     var.attrs.retain(|attr| attribute != attr);
 
-                    if ident == "Self" || ident == input.ident {
+                    if ident == input.ident {
                         self_attrs.extend(attrs);
                         continue;
                     }

--- a/tests/parent_specific.rs
+++ b/tests/parent_specific.rs
@@ -1,0 +1,114 @@
+use subenum::subenum;
+
+#[subenum(
+    Self(
+        doc = "[WebAssembly storage types](\
+            https://webassembly.github.io/spec/core/syntax/types.html#syntax-storagetype)\n",
+        derive(strum::EnumDiscriminants),
+        strum_discriminants(name(StorageType), derive(strum::FromRepr, PartialOrd, Ord, Hash))
+    ),
+    Val(
+        doc = "[WebAssembly value types](\
+            https://webassembly.github.io/spec/core/syntax/types.html#syntax-valtype)\n",
+        derive(strum::EnumDiscriminants),
+        strum_discriminants(name(ValType), derive(strum::FromRepr, PartialOrd, Ord, Hash))
+    ),
+    Num(
+        doc = "[WebAssembly number types](\
+            https://webassembly.github.io/spec/core/syntax/types.html#syntax-numtype)\n",
+        derive(strum::EnumDiscriminants),
+        strum_discriminants(name(NumType), derive(strum::FromRepr, PartialOrd, Ord, Hash))
+    ),
+    Int(
+        doc = "[WebAssembly integer types](\
+            https://webassembly.github.io/spec/core/syntax/types.html#syntax-inttype)\n",
+        derive(strum::EnumDiscriminants),
+        strum_discriminants(name(IntType), derive(strum::FromRepr, PartialOrd, Ord, Hash))
+    ),
+    Float(
+        doc = "[WebAssembly float types](\
+            https://webassembly.github.io/spec/core/syntax/types.html#syntax-floattype)\n",
+        derive(strum::EnumDiscriminants),
+        strum_discriminants(name(FloatType), derive(strum::FromRepr, PartialOrd, Ord, Hash))
+    ),
+    Pack(
+        doc = "[WebAssembly pack types](\
+            https://webassembly.github.io/spec/core/syntax/types.html#syntax-packtype)\n",
+        derive(strum::EnumDiscriminants),
+        strum_discriminants(name(PackType), derive(strum::FromRepr, PartialOrd, Ord, Hash))
+    )
+)]
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum Storage<R = usize> {
+    #[subenum(
+        Storage(doc = "16-bit integer type (Storage)\n"),
+        Pack(doc = "16-bit integer type (Pack)\n")
+    )]
+    I16(i16) = 0x77,
+
+    #[subenum(
+        Self(doc = "8-bit integer type (Storage)\n"),
+        Pack(doc = "8-bit integer type (Pack)\n")
+    )]
+    I8(i8) = 0x78,
+
+    #[subenum(
+        Self(doc = "128-bit vector type (Storage)\n"),
+        Val(doc = "128-bit vector type (Val)\n")
+    )]
+    V128([u8; 16]) = 0x7B,
+
+    #[subenum(
+        Self(doc = "64-bit float type (Storage)\n"),
+        Val(doc = "64-bit float type (Val)\n"),
+        Num(doc = "64-bit float type (Num)\n"),
+        Float(doc = "64-bit float type (Float)\n")
+    )]
+    F64(f64) = 0x7C,
+
+    #[subenum(
+        Storage(doc = "32-bit float type (Storage)\n"),
+        Val(doc = "32-bit float type (Val)\n"),
+        Num(doc = "32-bit float type (Num)\n"),
+        Float(doc = "32-bit float type (Float)\n")
+    )]
+    F32(f32) = 0x7D,
+
+    #[subenum(
+        Self(doc = "64-bit integer type (Storage)\n"),
+        Val(doc = "64-bit integer type (Val)\n"),
+        Num(doc = "64-bit integer type (Num)\n"),
+        Int(doc = "64-bit integer type (Int)\n")
+    )]
+    I64(i64) = 0x7E,
+
+    #[subenum(
+        Storage(doc = "32-bit integer type (Storage)\n"),
+        Val(doc = "32-bit integer type (Val)\n"),
+        Num(doc = "32-bit integer type (Num)\n"),
+        Int(doc = "32-bit integer type (Int)\n")
+    )]
+    I32(i32) = 0x7F,
+
+    #[subenum(
+        Self(doc = "Reference type (Storage)\n"),
+        Val(doc = "Reference type (Val)\n")
+    )]
+    Ref(R),
+}
+
+type _AllTypesPresent = (
+    Storage,
+    StorageType,
+    Val,
+    ValType,
+    Num,
+    NumType,
+    Int,
+    IntType,
+    Float,
+    FloatType,
+    Pack,
+    PackType,
+);

--- a/tests/parent_specific.rs
+++ b/tests/parent_specific.rs
@@ -1,7 +1,7 @@
 use subenum::subenum;
 
 #[subenum(
-    Self(
+    Storage(
         doc = "[WebAssembly storage types](\
             https://webassembly.github.io/spec/core/syntax/types.html#syntax-storagetype)\n",
         derive(strum::EnumDiscriminants),
@@ -48,19 +48,19 @@ pub enum Storage<R = usize> {
     I16(i16) = 0x77,
 
     #[subenum(
-        Self(doc = "8-bit integer type (Storage)\n"),
+        Storage(doc = "8-bit integer type (Storage)\n"),
         Pack(doc = "8-bit integer type (Pack)\n")
     )]
     I8(i8) = 0x78,
 
     #[subenum(
-        Self(doc = "128-bit vector type (Storage)\n"),
+        Storage(doc = "128-bit vector type (Storage)\n"),
         Val(doc = "128-bit vector type (Val)\n")
     )]
     V128([u8; 16]) = 0x7B,
 
     #[subenum(
-        Self(doc = "64-bit float type (Storage)\n"),
+        Storage(doc = "64-bit float type (Storage)\n"),
         Val(doc = "64-bit float type (Val)\n"),
         Num(doc = "64-bit float type (Num)\n"),
         Float(doc = "64-bit float type (Float)\n")
@@ -76,7 +76,7 @@ pub enum Storage<R = usize> {
     F32(f32) = 0x7D,
 
     #[subenum(
-        Self(doc = "64-bit integer type (Storage)\n"),
+        Storage(doc = "64-bit integer type (Storage)\n"),
         Val(doc = "64-bit integer type (Val)\n"),
         Num(doc = "64-bit integer type (Num)\n"),
         Int(doc = "64-bit integer type (Int)\n")
@@ -92,7 +92,7 @@ pub enum Storage<R = usize> {
     I32(i32) = 0x7F,
 
     #[subenum(
-        Self(doc = "Reference type (Storage)\n"),
+        Storage(doc = "Reference type (Storage)\n"),
         Val(doc = "Reference type (Val)\n")
     )]
     Ref(R),


### PR DESCRIPTION
Solves #26, #43, #50, and possibly #39.

Extends the subenum list to include the `Self` identifier, which only dispatches its associated attributes to the parent enum. The parent enum's own ident is also acknowledged.

Adds corresponding compile-time tests and doc examples.