### PR TITLE
fix: pass cfg attributes to From/TryFrom auto impls

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ pub enum Num {
 Bound lifetimes (e.g. `for<'a, 'b, 'c>`) are not currently supported. Please
 open a ticket if these are desired.
 
+`subenum` does not handle `cfg` attributes. To handle conditional compilation, consider using the [`cfg_eval`](https://github.com/rust-lang/rust/issues/82679) unstable feature or the [`cfg_eval`](https://crates.io/crates/cfg_eval) crate to pre-process `cfg` attributes.
+
 # Features
 - `default` - `std` and `error_trait`
 - `std` - Use standard library collections and allocators within this proc macro

--- a/src/build.rs
+++ b/src/build.rs
@@ -127,15 +127,34 @@ impl Enum {
             impl core::error::Error for #error {}
         );
 
-        let pats: Vec<TokenStream2> = self.variants.iter().map(variant_to_unary_pat).collect();
-
-        let from_child_arms = pats
+        let cfg_and_pats: Vec<(Vec<Attribute>, TokenStream2)> = self
+            .variants
             .iter()
-            .map(|pat| quote!(#child_ident::#pat => #parent_ident::#pat));
+            .map(|variant| {
+                let pat = variant_to_unary_pat(variant);
+                let cfg_attrs = variant
+                    .attrs
+                    .iter()
+                    .filter(|a| a.path().is_ident("cfg"))
+                    .cloned()
+                    .collect();
+                (cfg_attrs, pat)
+            })
+            .collect();
 
-        let try_from_parent_arms = pats
-            .iter()
-            .map(|pat| quote!(#parent_ident::#pat => Ok(#child_ident::#pat)));
+        let from_child_arms = cfg_and_pats.iter().map(|(cfg_attrs, pat)| {
+            quote!(
+                #(#cfg_attrs)*
+                #child_ident::#pat => #parent_ident::#pat
+            )
+        });
+
+        let try_from_parent_arms = cfg_and_pats.iter().map(|(cfg_attrs, pat)| {
+            quote!(
+                #(#cfg_attrs)*
+                #parent_ident::#pat => Ok(#child_ident::#pat)
+            )
+        });
 
         let inherited_derives = self
             .derives

--- a/src/build.rs
+++ b/src/build.rs
@@ -127,34 +127,15 @@ impl Enum {
             impl core::error::Error for #error {}
         );
 
-        let cfg_and_pats: Vec<(Vec<Attribute>, TokenStream2)> = self
-            .variants
+        let pats: Vec<TokenStream2> = self.variants.iter().map(variant_to_unary_pat).collect();
+
+        let from_child_arms = pats
             .iter()
-            .map(|variant| {
-                let pat = variant_to_unary_pat(variant);
-                let cfg_attrs = variant
-                    .attrs
-                    .iter()
-                    .filter(|a| a.path().is_ident("cfg"))
-                    .cloned()
-                    .collect();
-                (cfg_attrs, pat)
-            })
-            .collect();
+            .map(|pat| quote!(#child_ident::#pat => #parent_ident::#pat));
 
-        let from_child_arms = cfg_and_pats.iter().map(|(cfg_attrs, pat)| {
-            quote!(
-                #(#cfg_attrs)*
-                #child_ident::#pat => #parent_ident::#pat
-            )
-        });
-
-        let try_from_parent_arms = cfg_and_pats.iter().map(|(cfg_attrs, pat)| {
-            quote!(
-                #(#cfg_attrs)*
-                #parent_ident::#pat => Ok(#child_ident::#pat)
-            )
-        });
+        let try_from_parent_arms = pats
+            .iter()
+            .map(|pat| quote!(#parent_ident::#pat => Ok(#child_ident::#pat)));
 
         let inherited_derives = self
             .derives


### PR DESCRIPTION
I had a use case of having certain variants only when `cfg` is active

Here's a mock of what it looks like:
```rust
#[subenum::subenum(SubA, SubB, SubC)]
enum SubEnumTest {
    #[subenum(SubA, SubB)]
    Variant1,
    #[cfg(feature = "my-feature")]
    #[subenum(SubA)]
    Variant2,
    #[cfg(target_arch = "wasm32")]
    #[subenum(SubB)]
    Variant3,
    #[cfg(target_arch = "wasm32")]
    #[cfg(feature = "my-feature")]
    #[subenum(SubC)]
    Variant4,
}
```

Basically, subenum macro was generating `From` and `TryFrom` before `cfg` pruned those variants out, making compiler to complain that it is converting from a variant that doesn't exist.

By passing `cfg` to `From` and `TryFrom` impls, this problem gets solved.